### PR TITLE
Avoid '-' char in first position of id_rsa passphrase

### DIFF
--- a/pass/add_creds.sh
+++ b/pass/add_creds.sh
@@ -83,7 +83,7 @@ _generate_ssh_keys() {
   local temp_path="/tmp/${short_name}_id_rsa"
 
   # shellcheck disable=SC1003
-  pwgen -1 -s -r '\\"' -y 64 | passw cbi insert -m "${pw_store_path}/id_rsa.passphrase"
+  pwgen -1 -s -r '\\"-' -y 64 | passw cbi insert -m "${pw_store_path}/id_rsa.passphrase"
   passw cbi "${pw_store_path}/id_rsa.passphrase" | "${SCRIPT_FOLDER}"/../ssh-keygen-ni.sh -C "${email}" -f "${temp_path}"
 
   # Insert private and public key into pw store


### PR DESCRIPTION
For a generated passphrase with dash char in first position, failed the `ssh-keygen-ni.sh` while generate the ssh key and entering passphrase. 

Dash first char is interpreted as an option.

```shell
1 file changed, 0 insertions(+), 0 deletions(-)
 create mode 100644 bots/modeling.emf/github.com/id_rsa.passphrase.gpg
": must be -i, -h, -s, -null, -0, -raw, -break, or --]l9>QkR@Qp}G|?BDPz4LE
    while executing
"send "-\[S:sFS2XXXXXXX%\;4JiXw@-YkCXXXXXS~5\'ip\`\*rr\[FXXXXXXXFF~p%""
```

Proposition to avoid globally dash in passphrase.