### PR TITLE
Pass param org to script create_webhook to generate org webhook

### DIFF
--- a/github/setup_jenkins_github_integration.sh
+++ b/github/setup_jenkins_github_integration.sh
@@ -97,7 +97,7 @@ update_projects_bot_api() {
 
 create_org_webhook() {
   echo "# Creating organization webhook..."
-  "${SCRIPT_FOLDER}/create_webhook.sh" "${PROJECT_NAME}" "eclipse-${SHORT_NAME}"
+  "${SCRIPT_FOLDER}/create_webhook.sh" "org" "${PROJECT_NAME}" "eclipse-${SHORT_NAME}"
 }
 
 instructions_template() {


### PR DESCRIPTION
Pass param "org" to method `create_webhook.sh`, otherwise the script fails with wrong param. 