### PR TITLE
GitLab bot token runner scope

### DIFF
--- a/gitlab/gitlab_admin.sh
+++ b/gitlab/gitlab_admin.sh
@@ -218,7 +218,7 @@ create_api_token() {
   local expiry_date
   expiry_date="$(date --date="+365 days" +%Y-%m-%d)"
 
-  curl -sSL --header "${TOKEN_HEADER}" --request POST "${API_BASE_URL}/users/${user_id}/impersonation_tokens" --data-urlencode "name=${name}" --data "scopes[]=api"  --data "expires_at=${expiry_date}" | jq -r '.token'
+  curl -sSL --header "${TOKEN_HEADER}" --request POST "${API_BASE_URL}/users/${user_id}/impersonation_tokens" --data-urlencode "name=${name}" --data "scopes[]=api,create_runner"  --data "expires_at=${expiry_date}" | jq -r '.token'
 }
 
 create_bot_user() {


### PR DESCRIPTION
* Adding a new scope to bot token: allow runner creation
* Allowing to renew api-token, validity is a year.