### PR TITLE
Add missing source from common.sh

### DIFF
--- a/gpg/gpg_key_admin.sh
+++ b/gpg/gpg_key_admin.sh
@@ -17,6 +17,7 @@ IFS=$'\n\t'
 SCRIPT_FOLDER="$(dirname "$(readlink -f "${0}")")"
 #shellcheck disable=SC1091
 source "${SCRIPT_FOLDER}/../pass/pass_wrapper.sh"
+source "${SCRIPT_FOLDER}/../utils/common.sh"
 
 # TODO:
 # help menu generated from function names


### PR DESCRIPTION
That fixes ./gpg_key_admin.sh: line 173: _check_parameter: command not found 