### PR TITLE
fix sign up with 2FA and sign out

### DIFF
--- a/github/playwright/common.py
+++ b/github/playwright/common.py
@@ -71,7 +71,7 @@ def nav_to_token_settings(page):
 def signout(page):
     open_nav_menu(page)
     page.get_by_role("link", name="Sign out").click()
-    page.get_by_role("button", name="Sign out", exact=True).click()
+    page.get_by_role("button", name="Sign out from all accounts", exact=True).click()
 
 
 def login(page, project_name, username, password):
@@ -109,10 +109,6 @@ def login(page, project_name, username, password):
         page.get_by_placeholder("XXXXXX").fill(twofa_token_pass)
     else:
         print("Device verification page not found or skipped.")
-
-    if (page.get_by_role("heading", name="Two-factor authentication").is_visible()):
-        print("Found Verify 2FA page.")
-        page.get_by_role("button", name="Verify").click()
     
     # deal with confirm account settings page
     if (page.get_by_text("Confirm your account recovery settings").is_visible()):


### PR DESCRIPTION
* Fix: Resolved a timeout issue when clicking the sign-up button. Clicking the validation button is no longer necessary,  the script now handles the automatic form submission when filling in the 2FA code.

* Fix: Updated the sign out process. GitHub now displays two sign out buttons: one specific to the logged in user (with the username) and another for all accounts. This script now selects the "Sign out of all accounts" button.

Stack trace from the first fix:
```shell
 File "/home/.../.local/lib/python3.10/site-packages/playwright/_impl/_connection.py", line 514, in wrap_api_call
    raise rewrite_error(error, f"{parsed_st['apiName']}: {error}") from None
playwright._impl._errors.TimeoutError: Locator.click: Timeout 10000ms exceeded.
Call log:
waiting for get_by_role("button", name="Verify")
  -   locator resolved to <button disabled type="submit" data-view-component="true" data-disable-with="Verifying…" class="btn-primary btn btn-block">Verifying…</button>
  - attempting click action
  -   waiting for element to be visible, enabled and stable
  -   element is not enabled
  - retrying click action, attempt #1
  ``